### PR TITLE
Updates to address some AppCAT issues

### DIFF
--- a/src/MVC5/MvcMusicStore/Models/IdentityModels.cs
+++ b/src/MVC5/MvcMusicStore/Models/IdentityModels.cs
@@ -10,7 +10,7 @@ namespace MvcMusicStore.Models
     public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
         public ApplicationDbContext()
-            : base("DefaultConnection")
+            : base("MusicStoreConnection")
         {
         }
     }

--- a/src/MVC5/MvcMusicStore/MvcMusicStore.csproj
+++ b/src/MVC5/MvcMusicStore/MvcMusicStore.csproj
@@ -56,6 +56,12 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Configuration.ConfigurationBuilders.Base, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Configuration.ConfigurationBuilders.Base.3.0.0\lib\Net471\Microsoft.Configuration.ConfigurationBuilders.Base.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Configuration.ConfigurationBuilders.Environment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Configuration.ConfigurationBuilders.Environment.3.0.0\lib\Net471\Microsoft.Configuration.ConfigurationBuilders.Environment.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/src/MVC5/MvcMusicStore/Web.config
+++ b/src/MVC5/MvcMusicStore/Web.config
@@ -7,12 +7,12 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    <section name="configBuilders" type="System.Configuration.ConfigurationBuildersSection,               System.Configuration, Version=4.0.0.0, Culture=neutral,               PublicKeyToken=b03f5f7f11d50a3a" restartOnExternalChanges="false" requirePermission="false" />
+    <section name="configBuilders" type="System.Configuration.ConfigurationBuildersSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" restartOnExternalChanges="false" requirePermission="false" />
   </configSections>
   <configBuilders>
     <builders>
-      <add name="MyEnvironment" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder,          Microsoft.Configuration.ConfigurationBuilders.Environment,          Version=1.0.0.0, Culture=neutral" />
-      <!-- Todo: Add additional config builders here for services like Azure App Configuration and Azure Key Vault -->
+      <add name="MyEnvironment" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+	  <!-- Todo: Add additional config builders here for services like Azure App Configuration and Azure Key Vault -->
     </builders>
   </configBuilders>
   <connectionStrings configBuilders="MyEnvironment">
@@ -69,11 +69,35 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/MVC5/MvcMusicStore/Web.config
+++ b/src/MVC5/MvcMusicStore/Web.config
@@ -4,23 +4,30 @@
   http://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
-	<configSections>
-		<!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-		<section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-	</configSections>
-	<connectionStrings>
-		<add name="DefaultConnection" connectionString="Server=localhost;Database=mvcmusicstore001;Trusted_Connection=True;" providerName="System.Data.SqlClient" />
-		<add name="MusicStoreEntities" connectionString="Server=localhost;Database=mvcmusicstore001;Trusted_Connection=True;" providerName="System.Data.SqlClient" />
-	</connectionStrings>
-	<appSettings>
-		<add key="DefaultAdminUsername" value="Administrator" />
-		<add key="DefaultAdminPassword" value="YouShouldChangeThisPassword" />
-		<add key="webpages:Version" value="3.0.0.0" />
-		<add key="webpages:Enabled" value="false" />
-		<add key="ClientValidationEnabled" value="true" />
-		<add key="UnobtrusiveJavaScriptEnabled" value="true" />
-	</appSettings>
-	<!--
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="configBuilders" type="System.Configuration.ConfigurationBuildersSection,               System.Configuration, Version=4.0.0.0, Culture=neutral,               PublicKeyToken=b03f5f7f11d50a3a" restartOnExternalChanges="false" requirePermission="false" />
+  </configSections>
+  <configBuilders>
+    <builders>
+      <add name="MyEnvironment" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder,          Microsoft.Configuration.ConfigurationBuilders.Environment,          Version=1.0.0.0, Culture=neutral" />
+      <!-- Todo: Add additional config builders here for services like Azure App Configuration and Azure Key Vault -->
+    </builders>
+  </configBuilders>
+  <connectionStrings configBuilders="MyEnvironment">
+    <add name="MusicStoreConnection" connectionString="Server=Provided by Connected Service or environment config builder" providerName="System.Data.SqlClient" />
+    <add name="MusicStoreEntities" connectionString="Server=Provided by Connected Service or environment config builder" providerName="System.Data.SqlClient" />
+  </connectionStrings>
+  <appSettings configBuilders="MyEnvironment">
+    <add key="DefaultAdminUsername" value="Administrator" />
+    <add key="DefaultAdminPassword" value="YouShouldChangeThisPassword" />
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+  </appSettings>
+  <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
     The following attributes can be set on the <httpRuntime> tag.
@@ -28,60 +35,56 @@
         <httpRuntime targetFramework="4.8" />
       </system.Web>
   -->
-	<system.web>
-		<authentication mode="None" />
-		<compilation debug="true" targetFramework="4.8" />
-		<httpRuntime targetFramework="4.5" />
-		<customErrors mode="Off" />
-	</system.web>
-	<system.webServer>
-		<modules>
-			<remove name="FormsAuthenticationModule" />
-		</modules>
-		<handlers>
-			<remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-			<remove name="OPTIONSVerbHandler" />
-			<remove name="TRACEVerbHandler" />
-			<add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler"	      preCondition="integratedMode,runtimeVersionv4.0" />
-			<add name="NSwag" path="swagger" verb="*" type="System.Web.Handlers.TransferRequestHandler"
-				 preCondition="integratedMode,runtimeVersionv4.0" />
-		</handlers>
-	</system.webServer>
-	<runtime>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="1.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="1.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
-			</dependentAssembly>
-		</assemblyBinding>
-	</runtime>
-
-
-
-	<entityFramework>
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
-			<parameters>
-				<parameter value="v11.0" />
-			</parameters>
-		</defaultConnectionFactory>
-		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
-		</providers>
-	</entityFramework>
+  <system.web>
+    <authentication mode="None" />
+    <compilation debug="true" targetFramework="4.8" />
+    <httpRuntime targetFramework="4.5" />
+    <customErrors mode="Off" />
+  </system.web>
+  <system.webServer>
+    <modules>
+      <remove name="FormsAuthenticationModule" />
+    </modules>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <add name="NSwag" path="swagger" verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v11.0" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
 </configuration>

--- a/src/MVC5/MvcMusicStore/packages.config
+++ b/src/MVC5/MvcMusicStore/packages.config
@@ -16,6 +16,8 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.3.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net48" />
+  <package id="Microsoft.Configuration.ConfigurationBuilders.Base" version="3.0.0" targetFramework="net48" />
+  <package id="Microsoft.Configuration.ConfigurationBuilders.Environment" version="3.0.0" targetFramework="net48" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net48" />
   <package id="Microsoft.Owin.FileSystems" version="4.2.2" targetFramework="net48" />


### PR DESCRIPTION
This adds config builder usage to MvcMusicStore and removes hard-coded SQL connection strings to address a couple AppCAT issues.

Note that this means running the app locally will require setting environment variables to provide the connection string. The environment variables `MusicStoreConnection` and `MusicStoreEntities` both need set. To get the same behavior as before, they would need set them to `Server=localhost;Database=mvcmusicstore001;Trusted_Connection=True;`